### PR TITLE
Handle database_id in link_to_page blocks

### DIFF
--- a/notion_to_md/notion_to_md.py
+++ b/notion_to_md/notion_to_md.py
@@ -232,6 +232,10 @@ class NotionToMarkdown(NotionToMarkdownBase):
                 block_content = {
                     "url": f"https://www.notion.so/{block[block_type]['page_id']}"
                 }
+            elif block_type == "link_to_page" and block[block_type].get('type') == "database_id":
+                block_content = {
+                    "url": f"https://www.notion.so/{block[block_type]['database_id']}"
+                }
             else:
                 block_content = block[block_type]
             return md.link(block_type, block_content['url'])
@@ -483,6 +487,10 @@ class NotionToMarkdownAsync(NotionToMarkdownBase):
             if block_type == "link_to_page" and block[block_type].get('type') == "page_id":
                 block_content = {
                     "url": f"https://www.notion.so/{block[block_type]['page_id']}"
+                }
+            elif block_type == "link_to_page" and block[block_type].get('type') == "database_id":
+                block_content = {
+                    "url": f"https://www.notion.so/{block[block_type]['database_id']}"
                 }
             else:
                 block_content = block[block_type]


### PR DESCRIPTION
link_to_page can sometimes lead to database and then we have 
```
KeyError: 'url'
```