### PR TITLE
fix: allow empty urls instead of breaking transformation to md

### DIFF
--- a/notion_to_md/notion_to_md.py
+++ b/notion_to_md/notion_to_md.py
@@ -238,7 +238,8 @@ class NotionToMarkdown(NotionToMarkdownBase):
                 }
             else:
                 block_content = block[block_type]
-            return md.link(block_type, block_content['url'])
+            url = block_content.get('url', '')
+            return md.link(block_type, url)
 
         elif block_type == "child_page":
             if not self.config["parse_child_pages"]:
@@ -494,7 +495,8 @@ class NotionToMarkdownAsync(NotionToMarkdownBase):
                 }
             else:
                 block_content = block[block_type]
-            return md.link(block_type, block_content['url'])
+            url = block_content.get('url', '')
+            return md.link(block_type, url)
 
         elif block_type == "child_page":
             if not self.config["parse_child_pages"]:


### PR DESCRIPTION
# Fix: Handle missing URLs in Notion link blocks

### Problem

When Notion returns blocks (bookmark, embed, link_preview, link_to_page) with a null or missing url, the code raised a KeyError during conversion, causing the entire page conversion to fail.

Error:
`KeyError: 'url'`

This occurred in both NotionToMarkdown and NotionToMarkdownAsync when processing blocks with null URLs.


### Solution

Changed URL access from direct dictionary access to .get() with a default empty string:

Before:
```url = block_content['url']  # Raises KeyError if missing/null```

After:
```url = block_content.get('url', '')  # Returns '' if missing/null```

This change was applied in both:
- NotionToMarkdown.block_to_markdown() (line 241)
- NotionToMarkdownAsync.block_to_markdown() (line 498)

## Behavior

- Blocks with null or missing URLs now return a markdown link with an empty href (e.g., [bookmark]())
- Page conversion continues instead of crashing
- No breaking changes for blocks with valid URLs

## Impact

- Prevents crashes when Notion returns blocks with null URLs
- Improves resilience to API variations
- Maintains backward compatibility

This fix ensures the library handles edge cases from the Notion API without failing.