### PR TITLE
fix: replace tab indentation with 4 spaces for proper Markdown nesting

### DIFF
--- a/notion_to_md/utils/md.py
+++ b/notion_to_md/utils/md.py
@@ -114,7 +114,7 @@ def add_tab_space(text: str, n: int = 0) -> str:
     if n <= 0:
         return text
 
-    tab = '\t'
+    tab = '    '
     if '\n' in text:
         lines = text.split('\n')
         return '\n'.join(f'{tab * n}{line}' for line in lines)
@@ -128,7 +128,7 @@ def divider() -> str:
 def toggle(summary: Optional[str] = None, children: Optional[str] = None) -> str:
     if not summary:
         return children or ''
-    return f"<details><summary>{summary}</summary>{children or ''}</details>"
+    return f"<details>\n<summary>{summary}</summary>\n{children or ''}\n</details>"
 
 
 def table(cells: List[List[str]]) -> str:

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -128,6 +128,18 @@ def test_image_to_base64():
     )
 
 
+def test_add_tab_space_uses_spaces():
+    result = md.add_tab_space("- item", 1)
+    assert result == "    - item"
+    assert "\t" not in result
+
+
+def test_add_tab_space_multiline():
+    result = md.add_tab_space("line1\nline2", 2)
+    assert result == "        line1\n        line2"
+    assert "\t" not in result
+
+
 def test_toggle_without_title():
     assert md.toggle(None, "content").replace(" ", "") == "content"
 
@@ -137,6 +149,6 @@ def test_toggle_empty_title_and_content():
 
 
 def test_toggle_with_title_and_content():
-    result = md.toggle("title", "content").replace(" ", "")
-    expected_output = "<details><summary>title</summary>content</details>"
+    result = md.toggle("title", "content")
+    expected_output = "<details>\n<summary>title</summary>\ncontent\n</details>"
     assert result == expected_output


### PR DESCRIPTION
## Summary

Syncs with JS upstream [`notion-to-md`](https://github.com/souvikinator/notion-to-md) to fix two divergences in the Python port:

1. `add_tab_space()` uses `\t` instead of 4 spaces — fixed in JS upstream via [`7af0f46`](https://github.com/souvikinator/notion-to-md/commit/7af0f46c2157598d01a5a40bdc513523fa272f06) (2025-03-07)
2. `toggle()` uses inline `<details>` instead of multiline — the JS original has been multiline since [`b520013`](https://github.com/souvikinator/notion-to-md/commit/b5200135efeb7bcaaa31c200c1df0d4102a6ba91) (2022-06-24), refined in [`90e64ae`](https://github.com/souvikinator/notion-to-md/commit/90e64aeef773e20248f8a741baf6c713e775f266) (2023-07-08)

### Changes

1. `add_tab_space()` in [`notion_to_md/utils/md.py`](https://github.com/SwordAndTea/notion-to-md-py/blob/main/notion_to_md/utils/md.py#L117): Replace `\t` with 4 spaces — matches [JS upstream `addTabSpace`](https://github.com/souvikinator/notion-to-md/blob/master/src/utils/md.ts). Tab indentation causes CommonMark parsers to interpret nested content as indented code blocks ([spec §4.4](https://spec.commonmark.org/0.31.2/#indented-code-blocks)).
2. `toggle()`: Change from inline `<details><summary>...</summary>...</details>` to multiline format matching [JS upstream `toggle`](https://github.com/souvikinator/notion-to-md/blob/master/src/utils/md.ts). The Python port incorrectly collapsed the multiline template literal into a single line during translation.
3. Added `test_add_tab_space_uses_spaces` and `test_add_tab_space_multiline` to verify space-based indentation (the JS upstream has no tests for `addTabSpace`, so these are new regression tests)
4. Updated `test_toggle_with_title_and_content` to validate exact multiline format (stricter than the [JS toggle test](https://github.com/souvikinator/notion-to-md/blob/master/src/utils/md.spec.ts) which strips all whitespace before comparison)

### Context

This Python port was created (2025-01-14) when the JS original still used tabs for `addTabSpace`. The JS upstream fixed this on 2025-03-07:
- Commit: [`7af0f46`](https://github.com/souvikinator/notion-to-md/commit/7af0f46c2157598d01a5a40bdc513523fa272f06)
- Message: "replace tabs with spaces for proper Markdown nesting"

For the `toggle()` function, the JS original has always used a multiline template literal ([`b520013`](https://github.com/souvikinator/notion-to-md/commit/b5200135efeb7bcaaa31c200c1df0d4102a6ba91)), but the Python port flattened it into an inline f-string during translation.

### Tests

All 34 tests pass.