### PR TITLE
fix: detect circular block references to prevent RecursionError

### DIFF
--- a/notion_to_md/notion_to_md.py
+++ b/notion_to_md/notion_to_md.py
@@ -217,8 +217,7 @@ class NotionToMarkdown(NotionToMarkdownBase):
                     else block_content['file']['url'])
 
             image_title = (image_caption_plain.strip() or
-                           link.split('/')[-1] if '/' in link
-                           else image_title)
+                           (link.split('/')[-1] if '/' in link else image_title))
 
             return md.image(image_title, link, self.config['convert_images_to_base64'])
 
@@ -243,7 +242,7 @@ class NotionToMarkdown(NotionToMarkdownBase):
                         if file_type == 'external'
                         else block_content['file']['url'])
 
-                title = caption.strip() or link.split('/')[-1] if '/' in link else title
+                title = caption.strip() or (link.split('/')[-1] if '/' in link else title)
                 return md.link(title, link)
 
 
@@ -360,7 +359,7 @@ class NotionToMarkdown(NotionToMarkdownBase):
         elif block_type == "callout":
             callout_string = ""
             if not block['has_children']:
-                return md.callout(callout_string, block['callout'].get('icon'))
+                return md.callout(parsed_data, block['callout'].get('icon'))
 
             if block['id'] in _visited_block_ids:
                 return md.callout(parsed_data, block['callout'].get('icon'))
@@ -511,8 +510,7 @@ class NotionToMarkdownAsync(NotionToMarkdownBase):
                     else block_content['file']['url'])
 
             image_title = (image_caption_plain.strip() or
-                           link.split('/')[-1] if '/' in link
-                           else image_title)
+                           (link.split('/')[-1] if '/' in link else image_title))
 
             return await md.image_async(image_title, link, self.config['convert_images_to_base64'])
 
@@ -537,7 +535,7 @@ class NotionToMarkdownAsync(NotionToMarkdownBase):
                         if file_type == 'external'
                         else block_content['file']['url'])
 
-                title = caption.strip() or link.split('/')[-1] if '/' in link else title
+                title = caption.strip() or (link.split('/')[-1] if '/' in link else title)
                 return md.link(title, link)
 
 
@@ -654,7 +652,7 @@ class NotionToMarkdownAsync(NotionToMarkdownBase):
         elif block_type == "callout":
             callout_string = ""
             if not block['has_children']:
-                return md.callout(callout_string, block['callout'].get('icon'))
+                return md.callout(parsed_data, block['callout'].get('icon'))
 
             if block['id'] in _visited_block_ids:
                 return md.callout(parsed_data, block['callout'].get('icon'))
@@ -697,7 +695,8 @@ class NotionToMarkdownAsync(NotionToMarkdownBase):
 
         parsed_data = ""
         block_content = comment.get("rich_text", [])
-        name = comment.get("display_name", {}).get("resolved_name", "Anonymous")
+        display_name = comment.get("display_name") or {}
+        name = display_name.get("resolved_name") or "Anonymous"
         if name:
             parsed_data += f"**{name}**: "
         for content in block_content:

--- a/notion_to_md/notion_to_md.py
+++ b/notion_to_md/notion_to_md.py
@@ -122,10 +122,13 @@ class NotionToMarkdown(NotionToMarkdownBase):
 
     def block_list_to_markdown(self, blocks: List[Dict] = None,
                                total_pages: Optional[int] = None,
-                               md_blocks: List[Dict] = None) -> List[Dict]:
+                               md_blocks: List[Dict] = None,
+                               _visited_block_ids: Optional[set] = None) -> List[Dict]:
         """Convert Notion blocks to markdown blocks"""
         if md_blocks is None:
             md_blocks = []
+        if _visited_block_ids is None:
+            _visited_block_ids = set()
         if not blocks:
             return md_blocks
 
@@ -140,6 +143,15 @@ class NotionToMarkdown(NotionToMarkdownBase):
                                block['synced_block'].get('synced_from')
                             else block['id'])
 
+                if block_id in _visited_block_ids:
+                    md_blocks.append({
+                        'type': block['type'],
+                        'block_id': block['id'],
+                        'parent': self.block_to_markdown(block, _visited_block_ids),
+                        'children': []
+                    })
+                    continue
+
                 child_blocks = get_block_children(self.notion_client,
                                                   block_id,
                                                   total_pages)
@@ -147,31 +159,38 @@ class NotionToMarkdown(NotionToMarkdownBase):
                 md_blocks.append({
                     'type': block['type'],
                     'block_id': block['id'],
-                    'parent': self.block_to_markdown(block),
+                    'parent': self.block_to_markdown(block, _visited_block_ids),
                     'children': []
                 })
 
                 if not (block['type'] in self.custom_transformers):
-                    # append blocks to md_blocks[-1]['children']
-                    self.block_list_to_markdown(
-                        child_blocks,
-                        total_pages,
-                        md_blocks[-1]['children'])
+                    _visited_block_ids.add(block_id)
+                    try:
+                        self.block_list_to_markdown(
+                            child_blocks,
+                            total_pages,
+                            md_blocks[-1]['children'],
+                            _visited_block_ids)
+                    finally:
+                        _visited_block_ids.discard(block_id)
                 continue
 
             md_blocks.append({
                 'type': block['type'],
                 'block_id': block['id'],
-                'parent': self.block_to_markdown(block),
+                'parent': self.block_to_markdown(block, _visited_block_ids),
                 'children': []
             })
 
         return md_blocks
 
-    def block_to_markdown(self, block: Dict) -> str:
+    def block_to_markdown(self, block: Dict, _visited_block_ids: Optional[set] = None) -> str:
         """Convert a single Notion block to markdown"""
         if not isinstance(block, dict) or 'type' not in block:
             return ""
+
+        if _visited_block_ids is None:
+            _visited_block_ids = set()
 
         block_type = block['type']
         parsed_data = ""
@@ -343,8 +362,17 @@ class NotionToMarkdown(NotionToMarkdownBase):
             if not block['has_children']:
                 return md.callout(callout_string, block['callout'].get('icon'))
 
+            if block['id'] in _visited_block_ids:
+                return md.callout(parsed_data, block['callout'].get('icon'))
+
             callout_children_object = get_block_children(self.notion_client, block['id'], 100)
-            callout_children = self.block_list_to_markdown(callout_children_object)
+            _visited_block_ids.add(block['id'])
+            try:
+                callout_children = self.block_list_to_markdown(
+                    callout_children_object,
+                    _visited_block_ids=_visited_block_ids)
+            finally:
+                _visited_block_ids.discard(block['id'])
 
             callout_string += f"{parsed_data}\n"
             for child in callout_children:
@@ -381,10 +409,13 @@ class NotionToMarkdownAsync(NotionToMarkdownBase):
 
     async def block_list_to_markdown(self, blocks: List[Dict] = None,
                                      total_pages: Optional[int] = None,
-                                     md_blocks: List[Dict] = None) -> List[Dict]:
+                                     md_blocks: List[Dict] = None,
+                                     _visited_block_ids: Optional[set] = None) -> List[Dict]:
         """Convert Notion blocks to markdown blocks"""
         if md_blocks is None:
             md_blocks = []
+        if _visited_block_ids is None:
+            _visited_block_ids = set()
         if not blocks:
             return md_blocks
 
@@ -393,7 +424,7 @@ class NotionToMarkdownAsync(NotionToMarkdownBase):
                     (block['type'] == 'child_page' and not self.config['parse_child_pages'])):
                 continue
 
-            content = await self.block_to_markdown(block)
+            content = await self.block_to_markdown(block, _visited_block_ids)
             if self.config['parse_comments']:
                 comments = (await self.notion_client.comments.list(block_id=block['id'])).get('results', [])
                 if comments:
@@ -407,6 +438,15 @@ class NotionToMarkdownAsync(NotionToMarkdownBase):
                                block['synced_block'].get('synced_from')
                             else block['id'])
 
+                if block_id in _visited_block_ids:
+                    md_blocks.append({
+                        'type': block['type'],
+                        'block_id': block['id'],
+                        'parent': content,
+                        'children': []
+                    })
+                    continue
+
                 child_blocks = await get_block_children_async(self.notion_client,
                                                               block_id,
                                                               total_pages)
@@ -419,9 +459,14 @@ class NotionToMarkdownAsync(NotionToMarkdownBase):
                 })
 
                 if not (block['type'] in self.custom_transformers):
-                    await self.block_list_to_markdown(child_blocks,
-                                                      total_pages,
-                                                      md_blocks[-1]['children'])
+                    _visited_block_ids.add(block_id)
+                    try:
+                        await self.block_list_to_markdown(child_blocks,
+                                                          total_pages,
+                                                          md_blocks[-1]['children'],
+                                                          _visited_block_ids)
+                    finally:
+                        _visited_block_ids.discard(block_id)
                 continue
 
             md_blocks.append({
@@ -433,10 +478,13 @@ class NotionToMarkdownAsync(NotionToMarkdownBase):
 
         return md_blocks
 
-    async def block_to_markdown(self, block: Dict) -> str:
+    async def block_to_markdown(self, block: Dict, _visited_block_ids: Optional[set] = None) -> str:
         """Convert a single Notion block to markdown"""
         if not isinstance(block, dict) or 'type' not in block:
             return ""
+
+        if _visited_block_ids is None:
+            _visited_block_ids = set()
 
         block_type = block['type']
         parsed_data = ""
@@ -608,8 +656,17 @@ class NotionToMarkdownAsync(NotionToMarkdownBase):
             if not block['has_children']:
                 return md.callout(callout_string, block['callout'].get('icon'))
 
+            if block['id'] in _visited_block_ids:
+                return md.callout(parsed_data, block['callout'].get('icon'))
+
             callout_children_object = await get_block_children_async(self.notion_client, block['id'], 100)
-            callout_children = await self.block_list_to_markdown(callout_children_object)
+            _visited_block_ids.add(block['id'])
+            try:
+                callout_children = await self.block_list_to_markdown(
+                    callout_children_object,
+                    _visited_block_ids=_visited_block_ids)
+            finally:
+                _visited_block_ids.discard(block['id'])
 
             callout_string += f"{parsed_data}\n"
             for child in callout_children:

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,31 @@
 from setuptools import setup, find_packages
 
+with open("README.md", encoding="utf-8") as f:
+    long_description = f.read()
+
 setup(
-    name="notion-to-md-py",  # Replace with your package name
+    name="notion-to-md-py",
     version="0.1.5",
-    packages=find_packages(),  # Automatically include the submodules
+    packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=[
         "httpx",  # Required based on `md.py`
         "pytablewriter", # Required based on `md.py`
         "notion-client",  # Required based on references to `notion_client`
     ],
-    extras_require={
-        "async": [
-            "asyncio",  # Used in async functionality
-        ]
-    },
     description="A package to convert Notion content into Markdown format",
-    long_description=open("README.md").read(),
+    long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/SwordAndTea/notion-to-md-py",
     author="Wei Xiang",
     author_email="xiangweiqaz@gmail.com",
     classifiers=[
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="notion-to-md-py",  # Replace with your package name
-    version="0.1.4",
+    version="0.1.5",
     packages=find_packages(),  # Automatically include the submodules
     install_requires=[
         "httpx",  # Required based on `md.py`

--- a/tests/test_notion_to_md.py
+++ b/tests/test_notion_to_md.py
@@ -3,6 +3,52 @@ from unittest.mock import MagicMock, AsyncMock
 from notion_to_md import NotionToMarkdown, NotionToMarkdownAsync
 
 
+def _make_paragraph_block(block_id: str, text: str, has_children: bool = False) -> dict:
+    return {
+        "id": block_id,
+        "type": "paragraph",
+        "has_children": has_children,
+        "paragraph": {
+            "rich_text": [{
+                "type": "text",
+                "plain_text": text,
+                "annotations": {},
+            }],
+        },
+    }
+
+
+def _make_callout_block(block_id: str, text: str, has_children: bool = True) -> dict:
+    return {
+        "id": block_id,
+        "type": "callout",
+        "has_children": has_children,
+        "callout": {
+            "icon": None,
+            "rich_text": [{
+                "type": "text",
+                "plain_text": text,
+                "annotations": {},
+            }],
+        },
+    }
+
+
+def _make_synced_block(block_id: str, synced_from_id: str, has_children: bool = True) -> dict:
+    return {
+        "id": block_id,
+        "type": "synced_block",
+        "has_children": has_children,
+        "synced_block": {
+            "synced_from": {"block_id": synced_from_id} if synced_from_id else None,
+        },
+    }
+
+
+def _children_response(blocks):
+    return {"results": blocks, "next_cursor": None}
+
+
 def test_block_to_markdown_calls_custom_transformer():
     custom_transformer_mock = MagicMock()
     n2m = NotionToMarkdown(notion_client={})
@@ -668,3 +714,174 @@ async def test_block_list_to_markdown_with_comments_containing_annotations():
     assert "**Sarah**: Check [**this link**](https://example.com)" in result[0]["parent"]
 
 
+def test_block_list_to_markdown_breaks_circular_references():
+    block_a = _make_paragraph_block("A", "block A", has_children=True)
+    block_b = _make_paragraph_block("B", "block B", has_children=True)
+
+    children_by_id = {
+        "A": _children_response([block_b]),
+        "B": _children_response([block_a]),
+    }
+
+    notion_client = MagicMock()
+    notion_client.blocks.children.list.side_effect = lambda block_id, start_cursor=None: (
+        children_by_id[block_id]
+    )
+
+    n2m = NotionToMarkdown(notion_client=notion_client)
+
+    result = n2m.block_list_to_markdown([block_a])
+
+    assert len(result) == 1
+    assert result[0]["block_id"] == "A"
+    assert len(result[0]["children"]) == 1
+    assert result[0]["children"][0]["block_id"] == "B"
+    # B's child is A again — appended as a leaf since A is on the recursion path
+    assert len(result[0]["children"][0]["children"]) == 1
+    assert result[0]["children"][0]["children"][0]["block_id"] == "A"
+    assert result[0]["children"][0]["children"][0]["children"] == []
+
+
+def test_block_list_to_markdown_self_referential_block():
+    block_self = _make_paragraph_block("S", "loop", has_children=True)
+
+    notion_client = MagicMock()
+    notion_client.blocks.children.list.return_value = _children_response([block_self])
+
+    n2m = NotionToMarkdown(notion_client=notion_client)
+
+    result = n2m.block_list_to_markdown([block_self])
+
+    assert len(result) == 1
+    assert result[0]["block_id"] == "S"
+    assert len(result[0]["children"]) == 1
+    assert result[0]["children"][0]["block_id"] == "S"
+    assert result[0]["children"][0]["children"] == []
+
+
+def test_block_list_to_markdown_visits_same_block_in_separate_branches():
+    """A block legitimately reachable twice via different branches should be
+    processed in each branch — only ancestor cycles are skipped."""
+    shared = _make_paragraph_block("shared", "shared", has_children=True)
+    leaf = _make_paragraph_block("leaf", "leaf", has_children=False)
+    parent_one = _make_paragraph_block("P1", "p1", has_children=True)
+    parent_two = _make_paragraph_block("P2", "p2", has_children=True)
+
+    children_by_id = {
+        "P1": _children_response([shared]),
+        "P2": _children_response([shared]),
+        "shared": _children_response([leaf]),
+    }
+
+    notion_client = MagicMock()
+    notion_client.blocks.children.list.side_effect = lambda block_id, start_cursor=None: (
+        children_by_id[block_id]
+    )
+
+    n2m = NotionToMarkdown(notion_client=notion_client)
+
+    result = n2m.block_list_to_markdown([parent_one, parent_two])
+
+    assert len(result) == 2
+    assert result[0]["children"][0]["block_id"] == "shared"
+    assert result[0]["children"][0]["children"][0]["block_id"] == "leaf"
+    assert result[1]["children"][0]["block_id"] == "shared"
+    assert result[1]["children"][0]["children"][0]["block_id"] == "leaf"
+
+
+def test_block_list_to_markdown_breaks_nested_callout_cycle():
+    """Cycle across two callouts via a synced_block:
+    C1 (callout) > C2 (callout) > S (synced_block, synced_from=C1) > fetches C1's children -> C2 again.
+    Without threading visited_ids through block_to_markdown's callout case, this loops forever
+    because each callout starts a fresh visited set.
+    """
+    c1 = _make_callout_block("C1", "outer")
+    c2 = _make_callout_block("C2", "inner")
+    synced = _make_synced_block("S", synced_from_id="C1")
+
+    children_by_id = {
+        "C1": _children_response([c2]),
+        "C2": _children_response([synced]),
+    }
+
+    notion_client = MagicMock()
+    notion_client.blocks.children.list.side_effect = lambda block_id, start_cursor=None: (
+        children_by_id[block_id]
+    )
+
+    n2m = NotionToMarkdown(notion_client=notion_client)
+
+    result = n2m.block_list_to_markdown([c1])
+
+    assert len(result) == 1
+    assert result[0]["block_id"] == "C1"
+
+
+def test_block_to_markdown_callout_self_reference():
+    """A callout whose own child syncs from itself — block_to_markdown's callout case
+    must propagate visited_ids so the inner block_list_to_markdown detects the cycle."""
+    c = _make_callout_block("C", "self")
+    synced = _make_synced_block("S", synced_from_id="C")
+
+    notion_client = MagicMock()
+    notion_client.blocks.children.list.return_value = _children_response([synced])
+
+    n2m = NotionToMarkdown(notion_client=notion_client)
+    md_str = n2m.block_to_markdown(c)
+
+    assert isinstance(md_str, str)
+    assert "self" in md_str
+
+
+@pytest.mark.asyncio
+async def test_block_list_to_markdown_breaks_nested_callout_cycle_async():
+    c1 = _make_callout_block("C1", "outer")
+    c2 = _make_callout_block("C2", "inner")
+    synced = _make_synced_block("S", synced_from_id="C1")
+
+    children_by_id = {
+        "C1": _children_response([c2]),
+        "C2": _children_response([synced]),
+    }
+
+    async def fake_list(block_id, start_cursor=None):
+        return children_by_id[block_id]
+
+    notion_client = MagicMock()
+    notion_client.blocks.children.list = AsyncMock(side_effect=fake_list)
+
+    n2m = NotionToMarkdownAsync(notion_client=notion_client)
+
+    result = await n2m.block_list_to_markdown([c1])
+
+    assert len(result) == 1
+    assert result[0]["block_id"] == "C1"
+
+
+@pytest.mark.asyncio
+async def test_block_list_to_markdown_breaks_circular_references_async():
+    block_a = _make_paragraph_block("A", "block A", has_children=True)
+    block_b = _make_paragraph_block("B", "block B", has_children=True)
+
+    children_by_id = {
+        "A": _children_response([block_b]),
+        "B": _children_response([block_a]),
+    }
+
+    async def fake_list(block_id, start_cursor=None):
+        return children_by_id[block_id]
+
+    notion_client = MagicMock()
+    notion_client.blocks.children.list = AsyncMock(side_effect=fake_list)
+
+    n2m = NotionToMarkdownAsync(notion_client=notion_client)
+
+    result = await n2m.block_list_to_markdown([block_a])
+
+    assert len(result) == 1
+    assert result[0]["block_id"] == "A"
+    assert len(result[0]["children"]) == 1
+    assert result[0]["children"][0]["block_id"] == "B"
+    assert len(result[0]["children"][0]["children"]) == 1
+    assert result[0]["children"][0]["children"][0]["block_id"] == "A"
+    assert result[0]["children"][0]["children"][0]["children"] == []


### PR DESCRIPTION
  ## Summary
  - Closes #7. Track block IDs along the current recursion path in
    `block_list_to_markdown` and `block_to_markdown` so cycles
    (synced-block loops, callout chains, self-references) terminate
    with empty `children` instead of overflowing the stack.
  - Path-based tracking (add before recurse, discard in `finally`):
    a block reachable through two unrelated branches is still rendered
    in each — only true ancestor cycles are skipped.
  - Threaded through the callout branch in `block_to_markdown` so
    callout-mediated cycles (e.g. callout → callout → synced_block
    pointing back) also terminate.
  - Bumps version to 0.1.5.
